### PR TITLE
Eager prof mod tempfile updates

### DIFF
--- a/tests/test_autoprofile.py
+++ b/tests/test_autoprofile.py
@@ -586,14 +586,14 @@ def test_autoprofile_from_stdin(
             proc.check_returncode()
 
         outfile, = temp_dpath.glob(expected_outfile)
+        lp_cmd = [sys.executable, '-m', 'line_profiler', str(outfile)]
+        lp_proc = ub.cmd(lp_cmd)
+        lp_proc.check_returncode()
         if view:
             raw_output = proc.stdout
         else:
-            lp_cmd = [sys.executable, '-m', 'line_profiler', str(outfile)]
-            proc = ub.cmd(lp_cmd)
-            raw_output = proc.stdout
+            raw_output = lp_proc.stdout
             print(raw_output)
-            proc.check_returncode()
 
     assert ('Function: add_one' in raw_output) == prof_mod
     assert 'Function: add_two' not in raw_output
@@ -601,6 +601,9 @@ def test_autoprofile_from_stdin(
     # If we're calling a separate process to view the results, the
     # script file will already have been deleted
     assert ('Function: main' in raw_output) == view
+    # Check that `main()` is scrubbed from the written file and doesn't
+    # result in spurious error messages
+    assert 'Could not find file' not in lp_proc.stdout
 
 
 @pytest.mark.parametrize(

--- a/tests/test_kernprof.py
+++ b/tests/test_kernprof.py
@@ -2,6 +2,7 @@ import contextlib
 import os
 import re
 import shlex
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -266,8 +267,8 @@ def test_kernprof_verbosity(flags, expected_stdout, expected_stderr):
 
 def test_kernprof_eager_preimport_bad_module():
     """
-    Test for the proper error messages when an error occurs in an
-    auto-generated pre-import module.
+    Test for the preservation of the full traceback when an error occurs
+    in an auto-generated pre-import module.
     """
     bad_module = '''raise Exception('Boo')'''
     with contextlib.ExitStack() as stack:
@@ -300,6 +301,40 @@ def test_kernprof_eager_preimport_bad_module():
     tmp_mod = match.group(2)
     assert not os.path.exists(tmp_mod)
     assert not os.path.exists(os.path.dirname(tmp_mod))
+
+
+@pytest.mark.parametrize('stdin', [True, False])
+def test_kernprof_bad_temp_script(stdin):
+    """
+    Test for the preservation of the full traceback when an error occurs
+    in a temporary script supplied via `kernprof -c` or `kernprof -`.
+    """
+    bad_script = '''1 / 0'''
+    with contextlib.ExitStack() as stack:
+        enter = stack.enter_context
+        enter(ub.ChDir(enter(tempfile.TemporaryDirectory())))
+        if stdin:
+            proc = subprocess.run(
+                ['kernprof', '-'],
+                input=bad_script, capture_output=True, text=True)
+        else:
+            proc = subprocess.run(['kernprof', '-c', bad_script],
+                                  capture_output=True, text=True)
+    # Check that the traceback is preserved
+    print(proc.stdout)
+    print(proc.stderr, file=sys.stderr)
+    assert proc.returncode
+    assert '1 / 0' in proc.stderr
+    assert 'ZeroDivisionError' in proc.stderr
+    # Check that the generated tempfiles are wiped
+    reverse_iter_lines = iter(reversed(proc.stderr.splitlines()))
+    next(line for line in reverse_iter_lines if '1 / 0' in line)
+    tb_header = next(reverse_iter_lines).strip()
+    match = re.match('File ([\'"])(.+)\\1, line [0-9]+, in .*', tb_header)
+    assert match
+    tmp_script = match.group(2)
+    assert not os.path.exists(tmp_script)
+    assert not os.path.exists(os.path.dirname(tmp_script))
 
 
 class TestKernprof(unittest.TestCase):


### PR DESCRIPTION
(Put here for review. Conflict with #1 should be minimal.)

- Tempfile deletion is now deferred to an `atexit` callback in case of exceptions so that the requisite files exist at traceback-formatting time.
- Profiling data generating by functions defined inside a temporary script (via `... | kernprof -` or `kernprof -c '...'` are now omitted from the written `.lprof` file (but are still shown with `kernprof -v` of course) to avoid the `Could not found file ...` error message when post-processing the `.lprof` file with `python -m line_profiler`.
- Added tests for the above.

FYI @Erotemic